### PR TITLE
FEATURE: MySql database implemented instead of H2

### DIFF
--- a/accounts/pom.xml
+++ b/accounts/pom.xml
@@ -10,10 +10,10 @@
 	</parent>
 	<groupId>com.eazybytes</groupId>
 	<artifactId>accounts</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.0.2-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>accounts</name>
-	<description>Microservice for accounts</description>
+	<description>Project for Accounts in Eazy Bank</description>
 	<url/>
 	<licenses>
 		<license/>
@@ -52,8 +52,8 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -78,10 +78,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-config</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-bus-amqp</artifactId>
 		</dependency>
 	</dependencies>
 	<dependencyManagement>
@@ -116,7 +112,7 @@
 				<version>3.3.2</version>
 				<configuration>
 					<to>
-						<image>solomonhykes/${project.artifactId}:s6</image>
+						<image>solomonhykes/${project.artifactId}:s7</image>
 					</to>
 				</configuration>
 			</plugin>

--- a/accounts/src/main/resources/application.yml
+++ b/accounts/src/main/resources/application.yml
@@ -3,28 +3,20 @@ server:
 spring:
  application:
   name: accounts
- datasource:
-  url: jdbc:h2:mem:testdb
-  driverClassName: org.h2.Driver
-  username: sa
-  password: ''
- h2:
-  console:
-   enabled: true
- jpa:
-  database-platform: org.hibernate.dialect.H2Dialect
-  hibernate:
-   ddl-auto: update
-  show-sql: true
- config:
-  import: "optional:configserver:http://localhost:8071/"
  profiles:
   active: "prod"
- rabbitmq:
-  host: "192.168.186.128"
-  port: 5672
-  username: "guest"
-  password: "guest"
+ datasource:
+  url: jdbc:mysql://192.168.186.128:4306/accountsdb
+  username: accounts
+  password: password
+ jpa:
+  show-sql: true
+ sql:
+  init:
+   mode: always
+ config:
+  import: "optional:configserver:http://localhost:8071/"
+
 management:
  endpoints:
   web:

--- a/accounts/target/classes/application.yml
+++ b/accounts/target/classes/application.yml
@@ -3,28 +3,20 @@ server:
 spring:
  application:
   name: accounts
- datasource:
-  url: jdbc:h2:mem:testdb
-  driverClassName: org.h2.Driver
-  username: sa
-  password: ''
- h2:
-  console:
-   enabled: true
- jpa:
-  database-platform: org.hibernate.dialect.H2Dialect
-  hibernate:
-   ddl-auto: update
-  show-sql: true
- config:
-  import: "optional:configserver:http://localhost:8071/"
  profiles:
   active: "prod"
- rabbitmq:
-  host: "192.168.186.128"
-  port: 5672
-  username: "guest"
-  password: "guest"
+ datasource:
+  url: jdbc:mysql://192.168.186.128:4306/accountsdb
+  username: accounts
+  password: password
+ jpa:
+  show-sql: true
+ sql:
+  init:
+   mode: always
+ config:
+  import: "optional:configserver:http://localhost:8071/"
+
 management:
  endpoints:
   web:

--- a/cards/pom.xml
+++ b/cards/pom.xml
@@ -10,10 +10,10 @@
 	</parent>
 	<groupId>com.eazybytes</groupId>
 	<artifactId>cards</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.0.2-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>cards</name>
-	<description>Project for Cards in Eazy Bytes</description>
+	<description>Project for Cards in Eazy Bank</description>
 	<url/>
 	<licenses>
 		<license/>
@@ -52,8 +52,8 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -78,10 +78,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-config</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-bus-amqp</artifactId>
 		</dependency>
 	</dependencies>
 	<dependencyManagement>
@@ -116,7 +112,7 @@
 				<version>3.3.2</version>
 				<configuration>
 					<to>
-						<image>solomonhykes/${project.artifactId}:s6</image>
+						<image>solomonhykes/${project.artifactId}:s7</image>
 					</to>
 				</configuration>
 			</plugin>

--- a/cards/src/main/java/com/eazybytes/cards/dto/CardDto.java
+++ b/cards/src/main/java/com/eazybytes/cards/dto/CardDto.java
@@ -38,7 +38,7 @@ public class CardDto {
             description = "Total Limit of card in case its type is CREDIT", example = "2500.00"
     )
     @DecimalMin(value = "500.00", inclusive = true, message = "The minimum valid amount is 500.00.")
-    @DecimalMax(value = "3000.00", inclusive = true, message = "The maximum valida amount is 3000.00.")
+    @DecimalMax(value = "3000.00", inclusive = true, message = "The maximum valid amount is 3000.00.")
     private BigDecimal totalLimit;
 
     @Schema(

--- a/cards/src/main/resources/application.yml
+++ b/cards/src/main/resources/application.yml
@@ -3,28 +3,20 @@ server:
 spring:
  application:
   name: cards
- datasource:
-  url: jdbc:h2:mem:testdb
-  driverClassName: org.h2.Driver
-  username: sa
-  password: ''
- h2:
-  console:
-   enabled: true
- jpa:
-  database-platform: org.hibernate.dialect.H2Dialect
-  hibernate:
-   ddl-auto: update
-  show-sql: true
- config:
-  import: "optional:configserver:http://localhost:8071/"
  profiles:
   active: "prod"
- rabbitmq:
-  host: "192.168.186.128"
-  port: 5672
-  username: "guest"
-  password: "guest"
+ datasource:
+  url: jdbc:mysql://192.168.186.128:5306/cardsdb
+  username: cards
+  password: password
+ jpa:
+  show-sql: true
+ sql:
+  init:
+   mode: always
+ config:
+  import: "optional:configserver:http://localhost:8071/"
+
 management:
  endpoints:
   web:

--- a/configserver/pom.xml
+++ b/configserver/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.eazybytes</groupId>
 	<artifactId>configserver</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.0.2-SNAPSHOT</version>
 	<name>configserver</name>
 	<description>Config Server for Spring Boot Projects</description>
 	<url/>
@@ -38,14 +38,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-config-server</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-bus-amqp</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-config-monitor</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -77,7 +69,7 @@
 				<version>3.3.2</version>
 				<configuration>
 					<to>
-						<image>solomonhykes/${project.artifactId}:s6</image>
+						<image>solomonhykes/${project.artifactId}:s7</image>
 					</to>
 				</configuration>
 			</plugin>

--- a/configserver/src/main/resources/application.yml
+++ b/configserver/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
   cloud:
     config:
       server:
-        #native:
+        native:
           #search-locations: "classpath:/config"
           #search-locations: "file:///C:/test/config"
         git:
@@ -16,11 +16,7 @@ spring:
           clone-on-start: true
           timeout: 5
           force-pull: true
-  rabbitmq:
-    host: "192.168.186.128"
-    port: 5672
-    username: "guest"
-    password: "guest"
+
 management:
   endpoints:
     web:

--- a/docker-compose/default/common-config.yml
+++ b/docker-compose/default/common-config.yml
@@ -3,6 +3,20 @@ services:
     networks:
       - eazybank
 
+  microservice-db-config:
+    extends:
+      service: network-deploy-service
+    image: mysql:8-oracle
+    healthcheck:
+      test: [ "CMD","mysqladmin","ping","-h","localhost" ]
+      interval: 80s
+      timeout: 30s
+      retries: 5
+      start_period: 120s
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_PASSWORD: password
+
   microservice-base-config:
     extends:
       service: network-deploy-service
@@ -10,12 +24,10 @@ services:
       resources:
         limits:
           memory: 700m
-    environment:
-      SPRING_RABBIT_MQ: "rabbit"
 
   microservice-configserver-config:
     extends:
       service: microservice-base-config
     environment:
       SPRING_PROFILES_ACTIVE: default
-      SPRING_CONFIG_IMPORT: configserver:http://configserver:8071
+      SPRING_CONFIG_IMPORT: configserver:http://configserver:8071/

--- a/docker-compose/default/docker-compose.yml
+++ b/docker-compose/default/docker-compose.yml
@@ -1,76 +1,102 @@
 services:
-  rabbit:
-    image: rabbitmq:3.13-management
-    hostname: rabbitmq
+  accountsdb:
+    image: mysql:8-oracle
+    container_name: "accountsdb"
     ports:
-      - "5672:5672"
-      - "15672:15672"
-    healthcheck:
-      test: rabbitmq-diagnostics check_port_connectivity
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 5s
+      - "4306:3306"
+    environment:
+      MYSQL_DATABASE: accountsdb
+      MYSQL_USER: accounts
     extends:
       file: common-config.yml
-      service: network-deploy-service
+      service: microservice-db-config
+
+  cardsdb:
+    image: mysql:8-oracle
+    container_name: cardsdb
+    ports:
+      - "5306:3306"
+    environment:
+      MYSQL_DATABASE: cardsdb
+      MYSQL_USER: cards
+    extends:
+      file: common-config.yml
+      service: microservice-db-config
+
+  loansdb:
+    image: mysql:8-oracle
+    container_name: loansdb
+    ports:
+      - "6306:3306"
+    environment:
+      MYSQL_DATABASE: loansdb
+      MYSQL_USER: loans
+    extends:
+      file: common-config.yml
+      service: microservice-db-config
 
   configserver:
-    image: "solomonhykes/configserver:s6"
-    container_name: "configserver-ms"
+    image: solomonhykes/configserver:s7
+    container_name: configserver
     ports:
       - "8071:8071"
-    depends_on:
-      rabbit:
-        condition: service_healthy
     healthcheck:
       test: "curl --fail --silent localhost:8071/actuator/health/readiness | grep UP || exit 1"
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 10s
+      interval: 80s
+      timeout: 30s
+      retries: 5
+      start_period: 120s
     extends:
       file: common-config.yml
       service: microservice-base-config
 
   accounts:
-    image: "solomonhykes/accounts:s6"
+    image: "solomonhykes/accounts:s7"
     container_name: "accounts-ms"
     ports:
       - "8080:8080"
     depends_on:
+      accountsdb:
+        condition: service_healthy
       configserver:
         condition: service_healthy
     environment:
       SPRING_APPLICATION_NAME: "accounts"
+      SPRING_DATASOURCE_URL: jdbc:mysql://accountsdb:3306/accountsdb
     extends:
       file: common-config.yml
       service: microservice-configserver-config
 
   cards:
-    image: "solomonhykes/cards:s6"
+    image: "solomonhykes/cards:s7"
     container_name: "cards-ms"
     ports:
       - "9000:9000"
     depends_on:
+      cardsdb:
+        condition: service_healthy
       configserver:
         condition: service_healthy
     environment:
       SPRING_APPLICATION_NAME: "cards"
+      SPRING_DATASOURCE_URL: jdbc:mysql://cardsdb:3306/cardsdb
     extends:
       file: common-config.yml
       service: microservice-configserver-config
 
   loans:
-    image: "solomonhykes/loans:s6"
+    image: "solomonhykes/loans:s7"
     container_name: "loans-ms"
     ports:
       - "8090:8090"
     depends_on:
+      loansdb:
+        condition: service_healthy
       configserver:
         condition: service_healthy
     environment:
       SPRING_APPLICATION_NAME: "loans"
+      SPRING_DATASOURCE_URL: jdbc:mysql://loansdb:3306/loansdb
     extends:
       file: common-config.yml
       service: microservice-configserver-config

--- a/docker-compose/prod/common-config.yml
+++ b/docker-compose/prod/common-config.yml
@@ -3,6 +3,20 @@ services:
     networks:
       - eazybank
 
+  microservice-db-config:
+    extends:
+      service: network-deploy-service
+    image: mysql:8-oracle
+    healthcheck:
+      test: [ "CMD","mysqladmin","ping","-h","localhost" ]
+      interval: 80s
+      timeout: 30s
+      retries: 5
+      start_period: 120s
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_PASSWORD: password
+
   microservice-base-config:
     extends:
       service: network-deploy-service
@@ -10,12 +24,10 @@ services:
       resources:
         limits:
           memory: 700m
-    environment:
-      SPRING_RABBIT_MQ: "rabbit"
 
   microservice-configserver-config:
     extends:
       service: microservice-base-config
     environment:
       SPRING_PROFILES_ACTIVE: prod
-      SPRING_CONFIG_IMPORT: configserver:http://configserver:8071
+      SPRING_CONFIG_IMPORT: configserver:http://configserver:8071/

--- a/docker-compose/prod/docker-compose.yml
+++ b/docker-compose/prod/docker-compose.yml
@@ -1,76 +1,102 @@
 services:
-  rabbit:
-    image: rabbitmq:3.13-management
-    hostname: rabbitmq
+  accountsdb:
+    image: mysql:8-oracle
+    container_name: "accountsdb"
     ports:
-      - "5672:5672"
-      - "15672:15672"
-    healthcheck:
-      test: rabbitmq-diagnostics check_port_connectivity
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 5s
+      - "4306:3306"
+    environment:
+      MYSQL_DATABASE: accountsdb
+      MYSQL_USER: accounts
     extends:
       file: common-config.yml
-      service: network-deploy-service
+      service: microservice-db-config
+
+  cardsdb:
+    image: mysql:8-oracle
+    container_name: cardsdb
+    ports:
+      - "5306:3306"
+    environment:
+      MYSQL_DATABASE: cardsdb
+      MYSQL_USER: cards
+    extends:
+      file: common-config.yml
+      service: microservice-db-config
+
+  loansdb:
+    image: mysql:8-oracle
+    container_name: loansdb
+    ports:
+      - "6306:3306"
+    environment:
+      MYSQL_DATABASE: loansdb
+      MYSQL_USER: loans
+    extends:
+      file: common-config.yml
+      service: microservice-db-config
 
   configserver:
-    image: "solomonhykes/configserver:s6"
-    container_name: "configserver-ms"
+    image: solomonhykes/configserver:s7
+    container_name: configserver
     ports:
       - "8071:8071"
-    depends_on:
-      rabbit:
-        condition: service_healthy
     healthcheck:
       test: "curl --fail --silent localhost:8071/actuator/health/readiness | grep UP || exit 1"
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 10s
+      interval: 80s
+      timeout: 30s
+      retries: 5
+      start_period: 120s
     extends:
       file: common-config.yml
       service: microservice-base-config
 
   accounts:
-    image: "solomonhykes/accounts:s6"
+    image: "solomonhykes/accounts:s7"
     container_name: "accounts-ms"
     ports:
       - "8080:8080"
     depends_on:
+      accountsdb:
+        condition: service_healthy
       configserver:
         condition: service_healthy
     environment:
       SPRING_APPLICATION_NAME: "accounts"
+      SPRING_DATASOURCE_URL: jdbc:mysql://accountsdb:3306/accountsdb
     extends:
       file: common-config.yml
       service: microservice-configserver-config
 
   cards:
-    image: "solomonhykes/cards:s6"
+    image: "solomonhykes/cards:s7"
     container_name: "cards-ms"
     ports:
       - "9000:9000"
     depends_on:
+      cardsdb:
+        condition: service_healthy
       configserver:
         condition: service_healthy
     environment:
       SPRING_APPLICATION_NAME: "cards"
+      SPRING_DATASOURCE_URL: jdbc:mysql://cardsdb:3306/cardsdb
     extends:
       file: common-config.yml
       service: microservice-configserver-config
 
   loans:
-    image: "solomonhykes/loans:s6"
+    image: "solomonhykes/loans:s7"
     container_name: "loans-ms"
     ports:
       - "8090:8090"
     depends_on:
+      loansdb:
+        condition: service_healthy
       configserver:
         condition: service_healthy
     environment:
       SPRING_APPLICATION_NAME: "loans"
+      SPRING_DATASOURCE_URL: jdbc:mysql://loansdb:3306/loansdb
     extends:
       file: common-config.yml
       service: microservice-configserver-config

--- a/docker-compose/qa/common-config.yml
+++ b/docker-compose/qa/common-config.yml
@@ -3,6 +3,20 @@ services:
     networks:
       - eazybank
 
+  microservice-db-config:
+    extends:
+      service: network-deploy-service
+    image: mysql:8-oracle
+    healthcheck:
+      test: [ "CMD","mysqladmin","ping","-h","localhost" ]
+      interval: 80s
+      timeout: 30s
+      retries: 5
+      start_period: 120s
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_PASSWORD: password
+
   microservice-base-config:
     extends:
       service: network-deploy-service
@@ -10,12 +24,10 @@ services:
       resources:
         limits:
           memory: 700m
-    environment:
-      SPRING_RABBIT_MQ: "rabbit"
 
   microservice-configserver-config:
     extends:
       service: microservice-base-config
     environment:
       SPRING_PROFILES_ACTIVE: qa
-      SPRING_CONFIG_IMPORT: configserver:http://configserver:8071
+      SPRING_CONFIG_IMPORT: configserver:http://configserver:8071/

--- a/docker-compose/qa/docker-compose.yml
+++ b/docker-compose/qa/docker-compose.yml
@@ -1,76 +1,102 @@
 services:
-  rabbit:
-    image: rabbitmq:3.13-management
-    hostname: rabbitmq
+  accountsdb:
+    image: mysql:8-oracle
+    container_name: "accountsdb"
     ports:
-      - "5672:5672"
-      - "15672:15672"
-    healthcheck:
-      test: rabbitmq-diagnostics check_port_connectivity
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 5s
+      - "4306:3306"
+    environment:
+      MYSQL_DATABASE: accountsdb
+      MYSQL_USER: accounts
     extends:
       file: common-config.yml
-      service: network-deploy-service
+      service: microservice-db-config
+
+  cardsdb:
+    image: mysql:8-oracle
+    container_name: cardsdb
+    ports:
+      - "5306:3306"
+    environment:
+      MYSQL_DATABASE: cardsdb
+      MYSQL_USER: cards
+    extends:
+      file: common-config.yml
+      service: microservice-db-config
+
+  loansdb:
+    image: mysql:8-oracle
+    container_name: loansdb
+    ports:
+      - "6306:3306"
+    environment:
+      MYSQL_DATABASE: loansdb
+      MYSQL_USER: loans
+    extends:
+      file: common-config.yml
+      service: microservice-db-config
 
   configserver:
-    image: "solomonhykes/configserver:s6"
-    container_name: "configserver-ms"
+    image: solomonhykes/configserver:s7
+    container_name: configserver
     ports:
       - "8071:8071"
-    depends_on:
-      rabbit:
-        condition: service_healthy
     healthcheck:
       test: "curl --fail --silent localhost:8071/actuator/health/readiness | grep UP || exit 1"
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 10s
+      interval: 80s
+      timeout: 30s
+      retries: 5
+      start_period: 120s
     extends:
       file: common-config.yml
       service: microservice-base-config
 
   accounts:
-    image: "solomonhykes/accounts:s6"
+    image: "solomonhykes/accounts:s7"
     container_name: "accounts-ms"
     ports:
       - "8080:8080"
     depends_on:
+      accountsdb:
+        condition: service_healthy
       configserver:
         condition: service_healthy
     environment:
       SPRING_APPLICATION_NAME: "accounts"
+      SPRING_DATASOURCE_URL: jdbc:mysql://accountsdb:3306/accountsdb
     extends:
       file: common-config.yml
       service: microservice-configserver-config
 
   cards:
-    image: "solomonhykes/cards:s6"
+    image: "solomonhykes/cards:s7"
     container_name: "cards-ms"
     ports:
       - "9000:9000"
     depends_on:
+      cardsdb:
+        condition: service_healthy
       configserver:
         condition: service_healthy
     environment:
       SPRING_APPLICATION_NAME: "cards"
+      SPRING_DATASOURCE_URL: jdbc:mysql://cardsdb:3306/cardsdb
     extends:
       file: common-config.yml
       service: microservice-configserver-config
 
   loans:
-    image: "solomonhykes/loans:s6"
+    image: "solomonhykes/loans:s7"
     container_name: "loans-ms"
     ports:
       - "8090:8090"
     depends_on:
+      loansdb:
+        condition: service_healthy
       configserver:
         condition: service_healthy
     environment:
       SPRING_APPLICATION_NAME: "loans"
+      SPRING_DATASOURCE_URL: jdbc:mysql://loansdb:3306/loansdb
     extends:
       file: common-config.yml
       service: microservice-configserver-config

--- a/loans/pom.xml
+++ b/loans/pom.xml
@@ -10,10 +10,10 @@
 	</parent>
 	<groupId>com.eazybytes</groupId>
 	<artifactId>loans</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.0.2-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>loans</name>
-	<description>Project for Loans in Eazy Bytes</description>
+	<description>Project for Loans in Eazy Bank</description>
 	<url/>
 	<licenses>
 		<license/>
@@ -52,8 +52,8 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -78,10 +78,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-config</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-bus-amqp</artifactId>
 		</dependency>
 	</dependencies>
 	<dependencyManagement>
@@ -119,7 +115,7 @@
 				<version>3.3.2</version>
 				<configuration>
 					<to>
-						<image>solomonhykes/${project.artifactId}:s6</image>
+						<image>solomonhykes/${project.artifactId}:s7</image>
 					</to>
 				</configuration>
 			</plugin>

--- a/loans/src/main/java/com/eazybytes/loans/controller/LoansController.java
+++ b/loans/src/main/java/com/eazybytes/loans/controller/LoansController.java
@@ -16,6 +16,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -34,6 +35,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping(path = "/api", produces = {MediaType.APPLICATION_JSON_VALUE})
 @Validated
+@RefreshScope
 public class LoansController {
 
     private final ILoansService iLoansService;

--- a/loans/src/main/resources/application.yml
+++ b/loans/src/main/resources/application.yml
@@ -1,32 +1,24 @@
 server:
-  port: 8090
+ port: 8090
 spring:
-  application:
-    name: loans
-  datasource:
-    url: jdbc:h2:mem:testdb
-    driverClassName: org.h2.Driver
-    username: sa
-    password: ''
-  h2:
-    console:
-      enabled: true
-  jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-  config:
-    import: "optional:configserver:http://localhost:8071/"
-  profiles:
-    active: "prod"
-  rabbitmq:
-    host: "192.168.186.128"
-    port: 5672
-    username: "guest"
-    password: "guest"
+ application:
+  name: loans
+ profiles:
+  active: "prod"
+ datasource:
+  url: jdbc:mysql://192.168.186.128:6306/loansdb
+  username: loans
+  password: password
+ jpa:
+  show-sql: true
+ sql:
+  init:
+   mode: always
+ config:
+  import: "optional:configserver:http://localhost:8071/"
+
 management:
-  endpoints:
-    web:
-      exposure:
-        include: "*"
+ endpoints:
+  web:
+   exposure:
+    include: "*"


### PR DESCRIPTION
- All dependencies related to RabbitMQ are removed from all the 3 microservices and the config server in last commit of this branch.
- The H2 database is replaced by MySql 8.
- The docker-compose file is updated to use common configurations from the common-config file.
- The LoansController uses the @RefreshScope annotation to allow the update live of the buildVersion property read using the @Value annotation.