### PR TITLE
Feature s12 - Add security to microservices

### DIFF
--- a/accounts/pom.xml
+++ b/accounts/pom.xml
@@ -135,7 +135,7 @@
 				<version>3.3.2</version>
 				<configuration>
 					<to>
-						<image>solomonhykes/${project.artifactId}:s11</image>
+						<image>solomonhykes/${project.artifactId}:s12</image>
 					</to>
 				</configuration>
 			</plugin>

--- a/cards/pom.xml
+++ b/cards/pom.xml
@@ -127,7 +127,7 @@
 				<version>3.3.2</version>
 				<configuration>
 					<to>
-						<image>solomonhykes/${project.artifactId}:s11</image>
+						<image>solomonhykes/${project.artifactId}:s12</image>
 					</to>
 				</configuration>
 			</plugin>

--- a/configserver/pom.xml
+++ b/configserver/pom.xml
@@ -80,7 +80,7 @@
 				<version>3.3.2</version>
 				<configuration>
 					<to>
-						<image>solomonhykes/${project.artifactId}:s11</image>
+						<image>solomonhykes/${project.artifactId}:s12</image>
 					</to>
 				</configuration>
 			</plugin>

--- a/docker-compose/default/common-config.yml
+++ b/docker-compose/default/common-config.yml
@@ -24,6 +24,10 @@ services:
       resources:
         limits:
           memory: 700m
+    environment:
+      JAVA_TOOL_OPTIONS: "-javaagent:/app/libs/opentelemetry-javaagent-1.27.0.jar"
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
+      OTEL_METRICS_EXPORTER: none
 
   microservice-configserver-config:
     extends:

--- a/docker-compose/default/docker-compose.yml
+++ b/docker-compose/default/docker-compose.yml
@@ -1,4 +1,234 @@
 services:
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:22.0.1
+    container_name: keycloak
+    ports:
+      - "7080:8080"
+    environment:
+      KEYCLOAK_ADMIN: "admin"
+      KEYCLOAK_ADMIN_PASSWORD: "admin"
+    command: "start-dev"
+    extends:
+      file: common-config.yml
+      service: network-deploy-service
+
+  read:
+    image: grafana/loki:3.1.0
+    command: "-config.file=/etc/loki/config.yaml -target=read"
+    ports:
+      - 3101:3100
+      - 7946
+      - 9095
+    volumes:
+      - ../observability/loki/loki-config.yaml:/etc/loki/config.yaml
+    depends_on:
+      - minio
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks: &loki-dns
+      eazybank:
+        aliases:
+          - loki
+
+  write:
+    image: grafana/loki:3.1.0
+    command: "-config.file=/etc/loki/config.yaml -target=write"
+    ports:
+      - 3102:3100
+      - 7946
+      - 9095
+    volumes:
+      - ../observability/loki/loki-config.yaml:/etc/loki/config.yaml
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      - minio
+    networks:
+      <<: *loki-dns
+
+  alloy:
+    image: grafana/alloy:latest
+    volumes:
+      - ../observability/alloy/alloy-local-config.yaml:/etc/alloy/config.alloy:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    ports:
+      - 12345:12345
+    depends_on:
+      - gateway
+    extends:
+      file: common-config.yml
+      service: network-deploy-service
+
+  minio:
+    image: minio/minio
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /data/loki-data && \
+        mkdir -p /data/loki-ruler && \
+        minio server /data
+    environment:
+      - MINIO_ROOT_USER=loki
+      - MINIO_ROOT_PASSWORD=supersecret
+      - MINIO_PROMETHEUS_AUTH_TYPE=public
+      - MINIO_UPDATE=off
+    ports:
+      - 9000
+    volumes:
+      - ./.data/minio:/data
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9000/minio/health/live" ]
+      interval: 15s
+      timeout: 20s
+      retries: 5
+    extends:
+      file: common-config.yml
+      service: network-deploy-service
+
+  prometheus:
+    image: prom/prometheus:v2.50.1
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ../observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    extends:
+      file: common-config.yml
+      service: network-deploy-service
+
+  tempo:
+    image: grafana/tempo:2.4.2
+    container_name: tempo
+    command: -config.file /etc/tempo-config.yml
+    ports:
+      - "3110:3100"
+      - "4317:4317"
+    volumes:
+      - ../observability/tempo/tempo.yml:/etc/tempo-config.yml
+    extends:
+      file: common-config.yml
+      service: microservice-base-config
+
+  grafana:
+    image: grafana/grafana:latest
+    environment:
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_LOG_LEVEL=debug
+    depends_on:
+      - gateway
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        /run.sh
+    ports:
+      - "3000:3000"
+    volumes:
+      - ../observability/grafana/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    extends:
+      file: common-config.yml
+      service: network-deploy-service
+
+  backend:
+    image: grafana/loki:3.1.0
+    volumes:
+      - ../observability/loki/loki-config.yaml:/etc/loki/config.yaml
+    ports:
+      - "3100"
+      - "7946"
+    command: "-config.file=/etc/loki/config.yaml -target=backend -legacy-read-mode=false"
+    depends_on:
+      - gateway
+    extends:
+      file: common-config.yml
+      service: network-deploy-service
+
+  gateway:
+    image: nginx:latest
+    depends_on:
+      - read
+      - write
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        cat <<EOF > /etc/nginx/nginx.conf
+        user  nginx;
+        worker_processes  5;  ## Default: 1
+
+        events {
+          worker_connections   1000;
+        }
+
+        http {
+          resolver 127.0.0.11;
+
+          server {
+            listen             3100;
+
+            location = / {
+              return 200 'OK';
+              auth_basic off;
+            }
+
+            location = /api/prom/push {
+              proxy_pass       http://write:3100\$$request_uri;
+            }
+
+            location = /api/prom/tail {
+              proxy_pass       http://read:3100\$$request_uri;
+              proxy_set_header Upgrade \$$http_upgrade;
+              proxy_set_header Connection "upgrade";
+            }
+
+            location ~ /api/prom/.* {
+              proxy_pass       http://read:3100\$$request_uri;
+            }
+
+            location = /loki/api/v1/push {
+              proxy_pass       http://write:3100\$$request_uri;
+            }
+
+            location = /loki/api/v1/tail {
+              proxy_pass       http://read:3100\$$request_uri;
+              proxy_set_header Upgrade \$$http_upgrade;
+              proxy_set_header Connection "upgrade";
+            }
+
+            location ~ /loki/api/.* {
+              proxy_pass       http://read:3100\$$request_uri;
+            }
+          }
+        }
+        EOF
+        /docker-entrypoint.sh nginx -g "daemon off;"
+    ports:
+      - "3100:3100"
+    healthcheck:
+      test: [ "CMD", "service", "nginx", "status" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    extends:
+      file: common-config.yml
+      service: network-deploy-service
+
   accountsdb:
     image: mysql:8-oracle
     container_name: "accountsdb"
@@ -36,7 +266,7 @@ services:
       service: microservice-db-config
 
   configserver:
-    image: solomonhykes/configserver:s11
+    image: solomonhykes/configserver:s12
     container_name: configserver-ms
     ports:
       - "8071:8071"
@@ -46,6 +276,8 @@ services:
       timeout: 30s
       retries: 5
       start_period: 120s
+    environment:
+      OTER_SERVICE_NAME: "configserver"
     extends:
       file: common-config.yml
       service: microservice-base-config
@@ -62,9 +294,9 @@ services:
     extends:
       file: common-config.yml
       service: network-deploy-service
-  
+
   eurekaserver:
-    image: solomonhykes/eurekaserver:s11
+    image: solomonhykes/eurekaserver:s12
     container_name: eurekaserver-ms
     ports:
       - "8070:8070"
@@ -77,17 +309,15 @@ services:
       timeout: 30s
       retries: 5
       start_period: 120s
+    environment:
+      SPRING_APPLICATION_NAME: "eurekaserver"
     extends:
       file: common-config.yml
       service: microservice-configserver-config
-    environment:
-      SPRING_APPLICATION_NAME: "eurekaserver"
-  
+
   accounts:
-    image: "solomonhykes/accounts:s11"
+    image: "solomonhykes/accounts:s12"
     container_name: "accounts-ms"
-    ports:
-      - "8080:8080"
     healthcheck:
       test: "curl --fail --silent localhost:8080/actuator/health/readiness | grep UP || exit 1"
       interval: 60s
@@ -104,15 +334,14 @@ services:
     environment:
       SPRING_APPLICATION_NAME: "accounts"
       SPRING_DATASOURCE_URL: jdbc:mysql://accountsdb:3306/accountsdb
+      OTER_SERVICE_NAME: "accounts"
     extends:
       file: common-config.yml
       service: microservice-eureka-config
 
   cards:
-    image: "solomonhykes/cards:s11"
+    image: "solomonhykes/cards:s12"
     container_name: "cards-ms"
-    ports:
-      - "9000:9000"
     healthcheck:
       test: "curl --fail --silent localhost:9000/actuator/health/readiness || grep UP | exit 1"
       interval: 60s
@@ -129,15 +358,14 @@ services:
     environment:
       SPRING_APPLICATION_NAME: "cards"
       SPRING_DATASOURCE_URL: jdbc:mysql://cardsdb:3306/cardsdb
+      OTER_SERVICE_NAME: "cards"
     extends:
       file: common-config.yml
       service: microservice-eureka-config
 
   loans:
-    image: "solomonhykes/loans:s11"
+    image: "solomonhykes/loans:s12"
     container_name: "loans-ms"
-    ports:
-      - "8090:8090"
     healthcheck:
       test: "curl --fail --silent localhost:8090/actuator/health/readiness || grep UP | exit 1"
       interval: 60s
@@ -154,37 +382,13 @@ services:
     environment:
       SPRING_APPLICATION_NAME: "loans"
       SPRING_DATASOURCE_URL: jdbc:mysql://loansdb:3306/loansdb
-    extends:
-      file: common-config.yml
-      service: microservice-eureka-config
-
-  loans1:
-    image: "solomonhykes/loans:s11"
-    container_name: "loans1-ms"
-    ports:
-      - "8091:8090"
-    healthcheck:
-      test: "curl --fail --silent localhost:8090/actuator/health/readiness || grep UP | exit 1"
-      interval: 60s
-      timeout: 30s
-      retries: 5
-      start_period: 80s
-    depends_on:
-      loansdb:
-        condition: service_healthy
-      configserver:
-        condition: service_healthy
-      eurekaserver:
-        condition: service_healthy
-    environment:
-      SPRING_APPLICATION_NAME: "loans"
-      SPRING_DATASOURCE_URL: jdbc:mysql://loansdb:3306/loansdb
+      OTER_SERVICE_NAME: "loans"
     extends:
       file: common-config.yml
       service: microservice-eureka-config
 
   gatewayserver:
-    image: "solomonhykes/gatewayserver:s11"
+    image: "solomonhykes/gatewayserver:s12"
     container_name: "gatewayserver-ms"
     ports:
       - "8072:8072"
@@ -195,14 +399,14 @@ services:
         condition: service_healthy
       loans:
         condition: service_healthy
-      loans1:
-        condition: service_healthy
     environment:
       SPRING_APPLICATION_NAME: "gatewayserver"
       SPRING_DATA_REDIS_CONNECT-TIMEOUT: 2s
       SPRING_DATA_REDIS_HOST: redis
       SPRING_DATA_REDIS_PORT: 6379
       SPRING_DATA_REDIS_TIMEOUT: 1s
+      OTER_SERVICE_NAME: "gatewayserver"
+      SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK-SET-URI: "http://keycloak:8080/realms/master/protocol/openid-connect/certs"
     extends:
       file: common-config.yml
       service: microservice-eureka-config

--- a/docker-compose/default/docker-compose.yml
+++ b/docker-compose/default/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       service: microservice-db-config
 
   configserver:
-    image: solomonhykes/configserver:s10
+    image: solomonhykes/configserver:s11
     container_name: configserver-ms
     ports:
       - "8071:8071"
@@ -64,7 +64,7 @@ services:
       service: network-deploy-service
   
   eurekaserver:
-    image: solomonhykes/eurekaserver:s10
+    image: solomonhykes/eurekaserver:s11
     container_name: eurekaserver-ms
     ports:
       - "8070:8070"
@@ -84,7 +84,7 @@ services:
       SPRING_APPLICATION_NAME: "eurekaserver"
   
   accounts:
-    image: "solomonhykes/accounts:s10"
+    image: "solomonhykes/accounts:s11"
     container_name: "accounts-ms"
     ports:
       - "8080:8080"
@@ -109,7 +109,7 @@ services:
       service: microservice-eureka-config
 
   cards:
-    image: "solomonhykes/cards:s10"
+    image: "solomonhykes/cards:s11"
     container_name: "cards-ms"
     ports:
       - "9000:9000"
@@ -134,7 +134,7 @@ services:
       service: microservice-eureka-config
 
   loans:
-    image: "solomonhykes/loans:s10"
+    image: "solomonhykes/loans:s11"
     container_name: "loans-ms"
     ports:
       - "8090:8090"
@@ -159,7 +159,7 @@ services:
       service: microservice-eureka-config
 
   loans1:
-    image: "solomonhykes/loans:s10"
+    image: "solomonhykes/loans:s11"
     container_name: "loans1-ms"
     ports:
       - "8091:8090"
@@ -184,7 +184,7 @@ services:
       service: microservice-eureka-config
 
   gatewayserver:
-    image: "solomonhykes/gatewayserver:s10"
+    image: "solomonhykes/gatewayserver:s11"
     container_name: "gatewayserver-ms"
     ports:
       - "8072:8072"

--- a/docker-compose/prod/docker-compose.yml
+++ b/docker-compose/prod/docker-compose.yml
@@ -1,4 +1,18 @@
 services:
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:22.0.1
+    container_name: keycloak
+    ports:
+      - "7080:8080"
+    environment:
+      KEYCLOAK_ADMIN: "admin"
+      KEYCLOAK_ADMIN_PASSWORD: "admin"
+    command: "start-dev"
+    extends:
+      file: common-config.yml
+      service: network-deploy-service
+
   read:
     image: grafana/loki:3.1.0
     command: "-config.file=/etc/loki/config.yaml -target=read"
@@ -252,7 +266,7 @@ services:
       service: microservice-db-config
 
   configserver:
-    image: solomonhykes/configserver:s11
+    image: solomonhykes/configserver:s12
     container_name: configserver-ms
     ports:
       - "8071:8071"
@@ -282,7 +296,7 @@ services:
       service: network-deploy-service
 
   eurekaserver:
-    image: solomonhykes/eurekaserver:s11
+    image: solomonhykes/eurekaserver:s12
     container_name: eurekaserver-ms
     ports:
       - "8070:8070"
@@ -302,10 +316,8 @@ services:
       service: microservice-configserver-config
 
   accounts:
-    image: "solomonhykes/accounts:s11"
+    image: "solomonhykes/accounts:s12"
     container_name: "accounts-ms"
-    ports:
-      - "8080:8080"
     healthcheck:
       test: "curl --fail --silent localhost:8080/actuator/health/readiness | grep UP || exit 1"
       interval: 60s
@@ -328,10 +340,8 @@ services:
       service: microservice-eureka-config
 
   cards:
-    image: "solomonhykes/cards:s11"
+    image: "solomonhykes/cards:s12"
     container_name: "cards-ms"
-    ports:
-      - "9000:9000"
     healthcheck:
       test: "curl --fail --silent localhost:9000/actuator/health/readiness || grep UP | exit 1"
       interval: 60s
@@ -354,10 +364,8 @@ services:
       service: microservice-eureka-config
 
   loans:
-    image: "solomonhykes/loans:s11"
+    image: "solomonhykes/loans:s12"
     container_name: "loans-ms"
-    ports:
-      - "8090:8090"
     healthcheck:
       test: "curl --fail --silent localhost:8090/actuator/health/readiness || grep UP | exit 1"
       interval: 60s
@@ -379,33 +387,8 @@ services:
       file: common-config.yml
       service: microservice-eureka-config
 
-  loans1:
-    image: "solomonhykes/loans:s11"
-    container_name: "loans1-ms"
-    ports:
-      - "8091:8090"
-    healthcheck:
-      test: "curl --fail --silent localhost:8090/actuator/health/readiness || grep UP | exit 1"
-      interval: 60s
-      timeout: 30s
-      retries: 5
-      start_period: 80s
-    depends_on:
-      loansdb:
-        condition: service_healthy
-      configserver:
-        condition: service_healthy
-      eurekaserver:
-        condition: service_healthy
-    environment:
-      SPRING_APPLICATION_NAME: "loans"
-      SPRING_DATASOURCE_URL: jdbc:mysql://loansdb:3306/loansdb
-    extends:
-      file: common-config.yml
-      service: microservice-eureka-config
-
   gatewayserver:
-    image: "solomonhykes/gatewayserver:s11"
+    image: "solomonhykes/gatewayserver:s12"
     container_name: "gatewayserver-ms"
     ports:
       - "8072:8072"
@@ -416,8 +399,6 @@ services:
         condition: service_healthy
       loans:
         condition: service_healthy
-      loans1:
-        condition: service_healthy
     environment:
       SPRING_APPLICATION_NAME: "gatewayserver"
       SPRING_DATA_REDIS_CONNECT-TIMEOUT: 2s
@@ -425,6 +406,7 @@ services:
       SPRING_DATA_REDIS_PORT: 6379
       SPRING_DATA_REDIS_TIMEOUT: 1s
       OTER_SERVICE_NAME: "gatewayserver"
+      SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK-SET-URI: "http://keycloak:8080/realms/master/protocol/openid-connect/certs"
     extends:
       file: common-config.yml
       service: microservice-eureka-config

--- a/docker-compose/qa/common-config.yml
+++ b/docker-compose/qa/common-config.yml
@@ -24,6 +24,10 @@ services:
       resources:
         limits:
           memory: 700m
+    environment:
+      JAVA_TOOL_OPTIONS: "-javaagent:/app/libs/opentelemetry-javaagent-1.27.0.jar"
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
+      OTEL_METRICS_EXPORTER: none
 
   microservice-configserver-config:
     extends:

--- a/docker-compose/qa/docker-compose.yml
+++ b/docker-compose/qa/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       service: microservice-db-config
 
   configserver:
-    image: solomonhykes/configserver:s10
+    image: solomonhykes/configserver:s11
     container_name: configserver-ms
     ports:
       - "8071:8071"
@@ -64,7 +64,7 @@ services:
       service: network-deploy-service
 
   eurekaserver:
-    image: solomonhykes/eurekaserver:s10
+    image: solomonhykes/eurekaserver:s11
     container_name: eurekaserver-ms
     ports:
       - "8070:8070"
@@ -84,7 +84,7 @@ services:
       SPRING_APPLICATION_NAME: "eurekaserver"
 
   accounts:
-    image: "solomonhykes/accounts:s10"
+    image: "solomonhykes/accounts:s11"
     container_name: "accounts-ms"
     ports:
       - "8080:8080"
@@ -109,7 +109,7 @@ services:
       service: microservice-eureka-config
 
   cards:
-    image: "solomonhykes/cards:s10"
+    image: "solomonhykes/cards:s11"
     container_name: "cards-ms"
     ports:
       - "9000:9000"
@@ -134,7 +134,7 @@ services:
       service: microservice-eureka-config
 
   loans:
-    image: "solomonhykes/loans:s10"
+    image: "solomonhykes/loans:s11"
     container_name: "loans-ms"
     ports:
       - "8090:8090"
@@ -159,7 +159,7 @@ services:
       service: microservice-eureka-config
 
   loans1:
-    image: "solomonhykes/loans:s10"
+    image: "solomonhykes/loans:s11"
     container_name: "loans1-ms"
     ports:
       - "8091:8090"
@@ -184,7 +184,7 @@ services:
       service: microservice-eureka-config
 
   gatewayserver:
-    image: "solomonhykes/gatewayserver:s10"
+    image: "solomonhykes/gatewayserver:s11"
     container_name: "gatewayserver-ms"
     ports:
       - "8072:8072"

--- a/docker-compose/qa/docker-compose.yml
+++ b/docker-compose/qa/docker-compose.yml
@@ -1,4 +1,234 @@
 services:
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:22.0.1
+    container_name: keycloak
+    ports:
+      - "7080:8080"
+    environment:
+      KEYCLOAK_ADMIN: "admin"
+      KEYCLOAK_ADMIN_PASSWORD: "admin"
+    command: "start-dev"
+    extends:
+      file: common-config.yml
+      service: network-deploy-service
+
+  read:
+    image: grafana/loki:3.1.0
+    command: "-config.file=/etc/loki/config.yaml -target=read"
+    ports:
+      - 3101:3100
+      - 7946
+      - 9095
+    volumes:
+      - ../observability/loki/loki-config.yaml:/etc/loki/config.yaml
+    depends_on:
+      - minio
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks: &loki-dns
+      eazybank:
+        aliases:
+          - loki
+
+  write:
+    image: grafana/loki:3.1.0
+    command: "-config.file=/etc/loki/config.yaml -target=write"
+    ports:
+      - 3102:3100
+      - 7946
+      - 9095
+    volumes:
+      - ../observability/loki/loki-config.yaml:/etc/loki/config.yaml
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      - minio
+    networks:
+      <<: *loki-dns
+
+  alloy:
+    image: grafana/alloy:latest
+    volumes:
+      - ../observability/alloy/alloy-local-config.yaml:/etc/alloy/config.alloy:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    ports:
+      - 12345:12345
+    depends_on:
+      - gateway
+    extends:
+      file: common-config.yml
+      service: network-deploy-service
+
+  minio:
+    image: minio/minio
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /data/loki-data && \
+        mkdir -p /data/loki-ruler && \
+        minio server /data
+    environment:
+      - MINIO_ROOT_USER=loki
+      - MINIO_ROOT_PASSWORD=supersecret
+      - MINIO_PROMETHEUS_AUTH_TYPE=public
+      - MINIO_UPDATE=off
+    ports:
+      - 9000
+    volumes:
+      - ./.data/minio:/data
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9000/minio/health/live" ]
+      interval: 15s
+      timeout: 20s
+      retries: 5
+    extends:
+      file: common-config.yml
+      service: network-deploy-service
+
+  prometheus:
+    image: prom/prometheus:v2.50.1
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ../observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    extends:
+      file: common-config.yml
+      service: network-deploy-service
+
+  tempo:
+    image: grafana/tempo:2.4.2
+    container_name: tempo
+    command: -config.file /etc/tempo-config.yml
+    ports:
+      - "3110:3100"
+      - "4317:4317"
+    volumes:
+      - ../observability/tempo/tempo.yml:/etc/tempo-config.yml
+    extends:
+      file: common-config.yml
+      service: microservice-base-config
+
+  grafana:
+    image: grafana/grafana:latest
+    environment:
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_LOG_LEVEL=debug
+    depends_on:
+      - gateway
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        /run.sh
+    ports:
+      - "3000:3000"
+    volumes:
+      - ../observability/grafana/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    extends:
+      file: common-config.yml
+      service: network-deploy-service
+
+  backend:
+    image: grafana/loki:3.1.0
+    volumes:
+      - ../observability/loki/loki-config.yaml:/etc/loki/config.yaml
+    ports:
+      - "3100"
+      - "7946"
+    command: "-config.file=/etc/loki/config.yaml -target=backend -legacy-read-mode=false"
+    depends_on:
+      - gateway
+    extends:
+      file: common-config.yml
+      service: network-deploy-service
+
+  gateway:
+    image: nginx:latest
+    depends_on:
+      - read
+      - write
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        cat <<EOF > /etc/nginx/nginx.conf
+        user  nginx;
+        worker_processes  5;  ## Default: 1
+
+        events {
+          worker_connections   1000;
+        }
+
+        http {
+          resolver 127.0.0.11;
+
+          server {
+            listen             3100;
+
+            location = / {
+              return 200 'OK';
+              auth_basic off;
+            }
+
+            location = /api/prom/push {
+              proxy_pass       http://write:3100\$$request_uri;
+            }
+
+            location = /api/prom/tail {
+              proxy_pass       http://read:3100\$$request_uri;
+              proxy_set_header Upgrade \$$http_upgrade;
+              proxy_set_header Connection "upgrade";
+            }
+
+            location ~ /api/prom/.* {
+              proxy_pass       http://read:3100\$$request_uri;
+            }
+
+            location = /loki/api/v1/push {
+              proxy_pass       http://write:3100\$$request_uri;
+            }
+
+            location = /loki/api/v1/tail {
+              proxy_pass       http://read:3100\$$request_uri;
+              proxy_set_header Upgrade \$$http_upgrade;
+              proxy_set_header Connection "upgrade";
+            }
+
+            location ~ /loki/api/.* {
+              proxy_pass       http://read:3100\$$request_uri;
+            }
+          }
+        }
+        EOF
+        /docker-entrypoint.sh nginx -g "daemon off;"
+    ports:
+      - "3100:3100"
+    healthcheck:
+      test: [ "CMD", "service", "nginx", "status" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    extends:
+      file: common-config.yml
+      service: network-deploy-service
+
   accountsdb:
     image: mysql:8-oracle
     container_name: "accountsdb"
@@ -36,7 +266,7 @@ services:
       service: microservice-db-config
 
   configserver:
-    image: solomonhykes/configserver:s11
+    image: solomonhykes/configserver:s12
     container_name: configserver-ms
     ports:
       - "8071:8071"
@@ -46,6 +276,8 @@ services:
       timeout: 30s
       retries: 5
       start_period: 120s
+    environment:
+      OTER_SERVICE_NAME: "configserver"
     extends:
       file: common-config.yml
       service: microservice-base-config
@@ -64,7 +296,7 @@ services:
       service: network-deploy-service
 
   eurekaserver:
-    image: solomonhykes/eurekaserver:s11
+    image: solomonhykes/eurekaserver:s12
     container_name: eurekaserver-ms
     ports:
       - "8070:8070"
@@ -77,17 +309,15 @@ services:
       timeout: 30s
       retries: 5
       start_period: 120s
+    environment:
+      SPRING_APPLICATION_NAME: "eurekaserver"
     extends:
       file: common-config.yml
       service: microservice-configserver-config
-    environment:
-      SPRING_APPLICATION_NAME: "eurekaserver"
 
   accounts:
-    image: "solomonhykes/accounts:s11"
+    image: "solomonhykes/accounts:s12"
     container_name: "accounts-ms"
-    ports:
-      - "8080:8080"
     healthcheck:
       test: "curl --fail --silent localhost:8080/actuator/health/readiness | grep UP || exit 1"
       interval: 60s
@@ -104,15 +334,14 @@ services:
     environment:
       SPRING_APPLICATION_NAME: "accounts"
       SPRING_DATASOURCE_URL: jdbc:mysql://accountsdb:3306/accountsdb
+      OTER_SERVICE_NAME: "accounts"
     extends:
       file: common-config.yml
       service: microservice-eureka-config
 
   cards:
-    image: "solomonhykes/cards:s11"
+    image: "solomonhykes/cards:s12"
     container_name: "cards-ms"
-    ports:
-      - "9000:9000"
     healthcheck:
       test: "curl --fail --silent localhost:9000/actuator/health/readiness || grep UP | exit 1"
       interval: 60s
@@ -129,15 +358,14 @@ services:
     environment:
       SPRING_APPLICATION_NAME: "cards"
       SPRING_DATASOURCE_URL: jdbc:mysql://cardsdb:3306/cardsdb
+      OTER_SERVICE_NAME: "cards"
     extends:
       file: common-config.yml
       service: microservice-eureka-config
 
   loans:
-    image: "solomonhykes/loans:s11"
+    image: "solomonhykes/loans:s12"
     container_name: "loans-ms"
-    ports:
-      - "8090:8090"
     healthcheck:
       test: "curl --fail --silent localhost:8090/actuator/health/readiness || grep UP | exit 1"
       interval: 60s
@@ -154,37 +382,13 @@ services:
     environment:
       SPRING_APPLICATION_NAME: "loans"
       SPRING_DATASOURCE_URL: jdbc:mysql://loansdb:3306/loansdb
-    extends:
-      file: common-config.yml
-      service: microservice-eureka-config
-
-  loans1:
-    image: "solomonhykes/loans:s11"
-    container_name: "loans1-ms"
-    ports:
-      - "8091:8090"
-    healthcheck:
-      test: "curl --fail --silent localhost:8090/actuator/health/readiness || grep UP | exit 1"
-      interval: 60s
-      timeout: 30s
-      retries: 5
-      start_period: 80s
-    depends_on:
-      loansdb:
-        condition: service_healthy
-      configserver:
-        condition: service_healthy
-      eurekaserver:
-        condition: service_healthy
-    environment:
-      SPRING_APPLICATION_NAME: "loans"
-      SPRING_DATASOURCE_URL: jdbc:mysql://loansdb:3306/loansdb
+      OTER_SERVICE_NAME: "loans"
     extends:
       file: common-config.yml
       service: microservice-eureka-config
 
   gatewayserver:
-    image: "solomonhykes/gatewayserver:s11"
+    image: "solomonhykes/gatewayserver:s12"
     container_name: "gatewayserver-ms"
     ports:
       - "8072:8072"
@@ -195,14 +399,14 @@ services:
         condition: service_healthy
       loans:
         condition: service_healthy
-      loans1:
-        condition: service_healthy
     environment:
       SPRING_APPLICATION_NAME: "gatewayserver"
       SPRING_DATA_REDIS_CONNECT-TIMEOUT: 2s
       SPRING_DATA_REDIS_HOST: redis
       SPRING_DATA_REDIS_PORT: 6379
       SPRING_DATA_REDIS_TIMEOUT: 1s
+      OTER_SERVICE_NAME: "gatewayserver"
+      SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK-SET-URI: "http://keycloak:8080/realms/master/protocol/openid-connect/certs"
     extends:
       file: common-config.yml
       service: microservice-eureka-config

--- a/eurekaserver/pom.xml
+++ b/eurekaserver/pom.xml
@@ -84,7 +84,7 @@
 				<version>3.3.2</version>
 				<configuration>
 					<to>
-						<image>solomonhykes/${project.artifactId}:s11</image>
+						<image>solomonhykes/${project.artifactId}:s12</image>
 					</to>
 				</configuration>
 			</plugin>

--- a/gatewayserver/pom.xml
+++ b/gatewayserver/pom.xml
@@ -120,7 +120,7 @@
 				<version>3.3.2</version>
 				<configuration>
 					<to>
-						<image>solomonhykes/${project.artifactId}:s11</image>
+						<image>solomonhykes/${project.artifactId}:s12</image>
 					</to>
 				</configuration>
 			</plugin>

--- a/gatewayserver/pom.xml
+++ b/gatewayserver/pom.xml
@@ -83,6 +83,18 @@
 			<version>${otelVersion}</version>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-oauth2-resource-server</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-oauth2-jose</artifactId>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/gatewayserver/src/main/java/com/eazybytes/gatewayserver/config/KeycloakRoleConverter.java
+++ b/gatewayserver/src/main/java/com/eazybytes/gatewayserver/config/KeycloakRoleConverter.java
@@ -1,0 +1,27 @@
+package com.eazybytes.gatewayserver.config;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class KeycloakRoleConverter implements Converter<Jwt, Collection<GrantedAuthority>> {
+    @Override
+    public Collection<GrantedAuthority> convert(Jwt source) {
+        Map<String, Object> realmAccess = (Map<String, Object>) source.getClaims().get("realm_access");
+        if (realmAccess == null || realmAccess.isEmpty()) {
+            return new ArrayList<>();
+        }
+        Collection<GrantedAuthority> returnValue = ((List<String>) realmAccess.get("roles"))
+                .stream().map(roleName -> "ROLE_" + roleName)
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+        return returnValue;
+    }
+}

--- a/gatewayserver/src/main/java/com/eazybytes/gatewayserver/config/SecurityConfig.java
+++ b/gatewayserver/src/main/java/com/eazybytes/gatewayserver/config/SecurityConfig.java
@@ -1,0 +1,25 @@
+package com.eazybytes.gatewayserver.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@Configuration
+@EnableWebFluxSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity serverHttpSecurity) {
+        serverHttpSecurity.authorizeExchange(exchanges -> exchanges.pathMatchers(HttpMethod.GET).permitAll()
+                .pathMatchers("/eazybank/accounts/**").authenticated()
+                .pathMatchers("/eazybank/cards/**").authenticated()
+                .pathMatchers("/eazybank/loans/**").authenticated())
+                .oauth2ResourceServer(oauth2ResourceServerSpec -> oauth2ResourceServerSpec.jwt(Customizer.withDefaults()));
+        serverHttpSecurity.csrf(ServerHttpSecurity.CsrfSpec::disable);
+        return serverHttpSecurity.build();
+    }
+}

--- a/gatewayserver/src/main/java/com/eazybytes/gatewayserver/config/SecurityConfig.java
+++ b/gatewayserver/src/main/java/com/eazybytes/gatewayserver/config/SecurityConfig.java
@@ -2,11 +2,17 @@ package com.eazybytes.gatewayserver.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverterAdapter;
 import org.springframework.security.web.server.SecurityWebFilterChain;
+import reactor.core.publisher.Mono;
 
 @Configuration
 @EnableWebFluxSecurity
@@ -15,11 +21,21 @@ public class SecurityConfig {
     @Bean
     public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity serverHttpSecurity) {
         serverHttpSecurity.authorizeExchange(exchanges -> exchanges.pathMatchers(HttpMethod.GET).permitAll()
-                .pathMatchers("/eazybank/accounts/**").authenticated()
-                .pathMatchers("/eazybank/cards/**").authenticated()
-                .pathMatchers("/eazybank/loans/**").authenticated())
-                .oauth2ResourceServer(oauth2ResourceServerSpec -> oauth2ResourceServerSpec.jwt(Customizer.withDefaults()));
+                .pathMatchers("/eazybank/accounts/**").hasRole("ACCOUNTS")
+                .pathMatchers("/eazybank/cards/**").hasRole("CARDS")
+                .pathMatchers("/eazybank/loans/**").hasRole("LOANS"))
+                .oauth2ResourceServer(oauth2ResourceServerSpec -> oauth2ResourceServerSpec.jwt(
+                        jwtSpec -> jwtSpec.jwtAuthenticationConverter(grantedAuthoritiesExtractor())));
+//                .oauth2ResourceServer(oauth2ResourceServerSpec -> oauth2ResourceServerSpec.jwt(Customizer.withDefaults()));
         serverHttpSecurity.csrf(ServerHttpSecurity.CsrfSpec::disable);
         return serverHttpSecurity.build();
+    }
+
+    private Converter<Jwt, Mono<AbstractAuthenticationToken>> grantedAuthoritiesExtractor() {
+        JwtAuthenticationConverter jwtAuthenticationConverter =
+                new JwtAuthenticationConverter();
+        jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter
+                (new KeycloakRoleConverter());
+        return new ReactiveJwtAuthenticationConverterAdapter(jwtAuthenticationConverter);
     }
 }

--- a/gatewayserver/src/main/resources/application.yml
+++ b/gatewayserver/src/main/resources/application.yml
@@ -21,6 +21,11 @@ spring:
   metrics:
     tags:
       application: ${spring.application.name}
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: "http://192.168.186.128:7080/realms/master/protocol/openid-connect/certs"
 
 management:
   endpoints:

--- a/loans/pom.xml
+++ b/loans/pom.xml
@@ -113,9 +113,6 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>
-					<image>
-						<name>solomonhykes/${project.artifactId}:s4</name>
-                    </image>
 					<excludes>
 						<exclude>
 							<groupId>org.projectlombok</groupId>
@@ -130,7 +127,7 @@
 				<version>3.3.2</version>
 				<configuration>
 					<to>
-						<image>solomonhykes/${project.artifactId}:s11</image>
+						<image>solomonhykes/${project.artifactId}:s12</image>
 					</to>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
This branch implements the following items:

- Security is added to the gatewayserver component through the use of Spring Security OAuth2. It allows access only for those requests whose path matches "/eazybank/xxxx/*", where xxxx is accounts, cards or loans. Then, it checks if the roles required are present in the credentials sent in the request.
- OAuth2 is used to authorize the access to resources in all 3 microservices (accounts, cards and loans).
- KeyCloak is added as a service in the docker-compose file. It allows strong authentication. In this case Client Credentials and Authorization Code grant type flows were tested.